### PR TITLE
suspend cores while waiting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ env:
 
 on:
   push:
-    branches: [ main ]
+    branches: [ sdawdisplay ]
   pull_request:
 
 jobs:
@@ -167,8 +167,8 @@ jobs:
           zip -r ../MiniDexed_${{ github.run_number }}_${{ needs.build64.outputs.git_info }}.zip .
           cd ..
 
-      - name: Upload to GitHub Releases (only when building from main branch)
-        if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Upload to GitHub Releases (only when building from sdawdisplay branch)
+        if: ${{ github.ref == 'refs/heads/sdawdisplay' }}
         run: |
           set -ex
           export UPLOADTOOL_ISPRERELEASE=true

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -482,7 +482,7 @@ void CMiniDexed::Run (unsigned nCore)
 		{
 			while (m_CoreStatus[nCore] != CoreStatusIdle)
 			{
-				// just wait
+				WaitForEvent ();
 			}
 		}
 
@@ -496,9 +496,11 @@ void CMiniDexed::Run (unsigned nCore)
 		while (1)
 		{
 			m_CoreStatus[nCore] = CoreStatusIdle;		// ready to be kicked
+			SendIPI (1, IPI_USER);
+
 			while (m_CoreStatus[nCore] == CoreStatusIdle)
 			{
-				// just wait
+				WaitForEvent ();
 			}
 
 			// now kicked from core 1
@@ -1321,6 +1323,7 @@ void CMiniDexed::ProcessSound (void)
 		{
 			assert (m_CoreStatus[nCore] == CoreStatusIdle);
 			m_CoreStatus[nCore] = CoreStatusBusy;
+			SendIPI (nCore, IPI_USER);
 		}
 
 		// process the TGs assigned to core 1
@@ -1336,7 +1339,7 @@ void CMiniDexed::ProcessSound (void)
 		{
 			while (m_CoreStatus[nCore] != CoreStatusIdle)
 			{
-				// just wait
+				WaitForEvent ();
 			}
 		}
 

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -30,6 +30,7 @@
 #include "serialmididevice.h"
 #include "perftimer.h"
 #include <fatfs/ff.h>
+#include <atomic>
 #include <stdint.h>
 #include <string>
 #include <circle/types.h>
@@ -327,8 +328,8 @@ private:
 
 #ifdef ARM_ALLOW_MULTI_CORE
 //	unsigned m_nActiveTGsLog2;
-	volatile TCoreStatus m_CoreStatus[CORES];
-	volatile unsigned m_nFramesToProcess;
+	std::atomic<TCoreStatus> m_CoreStatus[CORES];
+	std::atomic<unsigned> m_nFramesToProcess;
 	float32_t m_OutputLevel[CConfig::AllToneGenerators][CConfig::MaxChunkSize];
 #endif
 


### PR DESCRIPTION
It uses the WaitForEvent and SendIPI functions to signal between cores to sleep and wakeup.

I tested it with an USB power meter:

RPI3b+ with MiniLab 3
latest: 2.29W (idle)
this: 1.91W (idle)

RPI4 with MiniLab 3
latest: 2.81W (idle)  3.2W (play)
this: 2.45W (idle) 2.82W (play)

I tested it for two days, it worked without any problems.
